### PR TITLE
Remove lobby if empty

### DIFF
--- a/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
@@ -74,7 +74,10 @@ public class LobbyService {
             log.info("User {} left lobby with id: {}", user.get().getId(), lobby.getId());
             eventBus.publishEvent(new ServerMessageWrapper(new LeaveLobbySuccessfullyResponse(), cmw.session()));
             // TODO update clients of users in lobby #8
-            // TODO delete lobby if empty
+            if (lobby.getUsers().isEmpty()) {
+                lobbyStore.remove(lobby.getId());
+                log.info("Lobby {} was empty and was removed.", lobby.getId());
+            }
             updateLobbyListInfo();
         } else {
             log.info("Could not leave lobby. No user found for session.");


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

If the last user leaves a lobby, the lobby will no longer be stored on the server and be shown in the lobby list of the users. This should not be confused with the possibilities to delete a lobby by the lobby owner while still users are within the lobby. 

## Related Tickets & Documents

- Related Issue(s) #63 
- Closes #55 


