### PR TITLE
Add cell factory for lobby list view

### DIFF
--- a/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
@@ -3,6 +3,7 @@ package org.schlunzis.kurtama.client.fx.controller;
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Dialog;
+import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,11 +31,22 @@ public class MainMenuController {
     private final ISessionService sessionService;
 
     @FXML
-    private ListView<LobbyInfo> lobbiesListView; // TODO cell factory
+    private ListView<LobbyInfo> lobbiesListView;
 
     @FXML
     private void initialize() {
         lobbiesListView.setItems(sessionService.getLobbyList());
+        lobbiesListView.setCellFactory(lobbyInfoListView -> new ListCell<>() {
+            @Override
+            protected void updateItem(LobbyInfo lobbyInfo, boolean empty) {
+                super.updateItem(lobbyInfo, empty);
+                if (empty || lobbyInfo == null) {
+                    setText(null);
+                } else {
+                    setText(lobbyInfo.lobbyName() + " (" + lobbyInfo.users() + ")");
+                }
+            }
+        });
     }
 
     @FXML


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

The lobbylist will no longer display the object hashcode of the lobby but the lobbyname and the count of the users in the lobby.

## Related Tickets & Documents

- Closes #56 


