### PR TITLE
61 bug newly logged in users dont get the lobby info

### DIFF
--- a/client/src/main/java/org/schlunzis/kurtama/client/fx/scene/SceneController.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/fx/scene/SceneController.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.schlunzis.kurtama.client.fx.scene.events.SceneChangeEvent;
 import org.schlunzis.kurtama.common.messages.authentication.login.LoginSuccessfulResponse;
 import org.schlunzis.kurtama.common.messages.authentication.logout.LogoutSuccessfulResponse;
-import org.schlunzis.kurtama.common.messages.authentication.register.RegisterSuccessfullResponse;
+import org.schlunzis.kurtama.common.messages.authentication.register.RegisterSuccessfulResponse;
 import org.schlunzis.kurtama.common.messages.lobby.server.JoinLobbySuccessfullyResponse;
 import org.schlunzis.kurtama.common.messages.lobby.server.LeaveLobbySuccessfullyResponse;
 import org.schlunzis.kurtama.common.messages.lobby.server.LobbyCreatedSuccessfullyResponse;
@@ -31,7 +31,7 @@ public class SceneController {
     }
 
     @EventListener
-    public void onRegisterSuccessfulResponse(RegisterSuccessfullResponse rsr) {
+    public void onRegisterSuccessfulResponse(RegisterSuccessfulResponse rsr) {
         eventBus.publishEvent(new SceneChangeEvent(Scene.LOGIN));
     }
 

--- a/client/src/main/java/org/schlunzis/kurtama/client/service/impl/SessionService.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/service/impl/SessionService.java
@@ -34,6 +34,7 @@ public class SessionService implements ISessionService {
     @EventListener
     public void onLoginSuccessfulResponse(LoginSuccessfulResponse lsr) {
         currentUser = Optional.of(lsr.getUser());
+        lobbyList.setAll(lsr.getLobbyInfos());
     }
 
     @EventListener

--- a/common/src/main/java/org/schlunzis/kurtama/common/messages/authentication/login/LoginSuccessfulResponse.java
+++ b/common/src/main/java/org/schlunzis/kurtama/common/messages/authentication/login/LoginSuccessfulResponse.java
@@ -4,7 +4,10 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.schlunzis.kurtama.common.IUser;
+import org.schlunzis.kurtama.common.LobbyInfo;
 import org.schlunzis.kurtama.common.messages.IServerMessage;
+
+import java.util.Collection;
 
 @Data
 @AllArgsConstructor
@@ -14,5 +17,7 @@ public class LoginSuccessfulResponse implements IServerMessage {
     private IUser user;
 
     private String email;
+
+    private Collection<LobbyInfo> lobbyInfos;
 
 }

--- a/common/src/main/java/org/schlunzis/kurtama/common/messages/authentication/register/RegisterSuccessfulResponse.java
+++ b/common/src/main/java/org/schlunzis/kurtama/common/messages/authentication/register/RegisterSuccessfulResponse.java
@@ -2,5 +2,5 @@ package org.schlunzis.kurtama.common.messages.authentication.register;
 
 import org.schlunzis.kurtama.common.messages.IServerMessage;
 
-public class RegisterSuccessfullResponse implements IServerMessage {
+public class RegisterSuccessfulResponse implements IServerMessage {
 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

By adding a `LobbyInfo` collection to the `LoginSuccessfulResponse` a newly logged in user will be able to be presented with the currently available lobbies.

## Related Tickets & Documents

- Closes #61 


