### PR TITLE
Create an AbstractService in server

### DIFF
--- a/server/src/main/java/org/schlunzis/kurtama/server/auth/AuthenticationService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/auth/AuthenticationService.java
@@ -18,25 +18,34 @@ import org.schlunzis.kurtama.server.net.ISession;
 import org.schlunzis.kurtama.server.net.ServerMessageWrapper;
 import org.schlunzis.kurtama.server.user.DBUser;
 import org.schlunzis.kurtama.server.user.IUserStore;
+import org.schlunzis.kurtama.server.user.ServerUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 
+/**
+ * This class handles all login-, logout- and registration events. It also provides information about whether a user is
+ * logged in. If a user is logged in, a session for that user can be retrieved.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class AuthenticationService {
-
+public class AuthenticationService implements IAuthenticationService {
 
     private final ApplicationEventPublisher eventBus;
     private final UserSessionMap userSessionMap;
     private final IUserStore userStore;
     private final LobbyStore lobbyStore;
     private final PasswordEncoder passwordEncoder;
+
+    // ################################################
+    // Event Listeners
+    // ################################################
 
     @EventListener
     public void onLoginEvent(ClientMessageWrapper<LoginRequest> cmw) {
@@ -80,6 +89,10 @@ public class AuthenticationService {
         }
     }
 
+    // ################################################
+    // Other methods
+    // ################################################
+
     public boolean isLoggedIn(ISession session) {
         return userSessionMap.contains(session);
     }
@@ -88,5 +101,18 @@ public class AuthenticationService {
         return userSessionMap.getAllSessions();
     }
 
+    public Optional<ServerUser> getUserForSession(ISession session) {
+        return userSessionMap.get(session);
+    }
+
+    @Override
+    public Collection<ISession> getSessionsForUsers(Collection<ServerUser> users) {
+        return userSessionMap.getFor(users);
+    }
+
+    @Override
+    public Optional<ISession> getSessionForUser(ServerUser user) {
+        return userSessionMap.get(user);
+    }
 
 }

--- a/server/src/main/java/org/schlunzis/kurtama/server/auth/IAuthenticationService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/auth/IAuthenticationService.java
@@ -1,0 +1,52 @@
+package org.schlunzis.kurtama.server.auth;
+
+import org.schlunzis.kurtama.server.net.ISession;
+import org.schlunzis.kurtama.server.user.ServerUser;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public interface IAuthenticationService {
+
+    /**
+     * Returns true, if a user with the given session is logged in.
+     *
+     * @param session the session to check
+     * @return true, if a user is logged in, false otherwise
+     */
+    boolean isLoggedIn(ISession session);
+
+    /**
+     * Returns the sessions of all logged-in users.
+     *
+     * @return the sessions
+     */
+    Collection<ISession> getAllLoggedInSessions();
+
+    /**
+     * Returns the user associated with the session, if one exists. There might not be a user for that session, if they
+     * are not logged in.
+     *
+     * @param session the session to check for
+     * @return the user, if they are logged in
+     */
+    Optional<ServerUser> getUserForSession(ISession session);
+
+    /**
+     * This method returns sessions for logged-in users. The order of the sessions is not defined. If the amount of
+     * sessions returned is not equal to the amount of users given, then some of the users were not logged in.
+     *
+     * @param users the users to get the sessions for
+     * @return the sessions
+     */
+    Collection<ISession> getSessionsForUsers(Collection<ServerUser> users);
+
+    /**
+     * Returns the session for the given user. If the session is not present, the user is not logged-in.
+     *
+     * @param user the user
+     * @return the session
+     */
+    Optional<ISession> getSessionForUser(ServerUser user);
+
+}

--- a/server/src/main/java/org/schlunzis/kurtama/server/auth/UserSessionMap.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/auth/UserSessionMap.java
@@ -4,13 +4,10 @@ import org.schlunzis.kurtama.server.net.ISession;
 import org.schlunzis.kurtama.server.user.ServerUser;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 @Component
-public class UserSessionMap {
+class UserSessionMap {
 
     private final Map<ServerUser, ISession> map = new HashMap<>();
 
@@ -18,13 +15,20 @@ public class UserSessionMap {
         map.put(user, session);
     }
 
-    public ISession get(ServerUser user) {
-        return map.get(user);
+    public Optional<ISession> get(ServerUser user) {
+        return Optional.ofNullable(map.get(user));
     }
 
     public Optional<ServerUser> get(ISession session) {
-        Optional<Map.Entry<ServerUser, ISession>> optionalUser = map.entrySet().stream().filter(e -> e.getValue().equals(session)).findFirst();
-        return optionalUser.map(Map.Entry::getKey);
+        Optional<Map.Entry<ServerUser, ISession>> optionalEntry = map.entrySet().stream().filter(e -> e.getValue().equals(session)).findFirst();
+        return optionalEntry.map(Map.Entry::getKey);
+    }
+
+    public Collection<ISession> getFor(Collection<ServerUser> users) {
+        return users.stream()
+                .map(map::get)
+                .filter(Objects::nonNull)
+                .toList();
     }
 
     public Collection<ISession> getAllSessions() {

--- a/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
@@ -1,15 +1,14 @@
 package org.schlunzis.kurtama.server.lobby;
 
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.schlunzis.kurtama.common.LobbyInfo;
 import org.schlunzis.kurtama.common.messages.lobby.client.CreateLobbyRequest;
 import org.schlunzis.kurtama.common.messages.lobby.client.JoinLobbyRequest;
 import org.schlunzis.kurtama.common.messages.lobby.client.LeaveLobbyRequest;
 import org.schlunzis.kurtama.common.messages.lobby.server.*;
-import org.schlunzis.kurtama.server.auth.UserSessionMap;
+import org.schlunzis.kurtama.server.auth.AuthenticationService;
 import org.schlunzis.kurtama.server.net.ClientMessageWrapper;
-import org.schlunzis.kurtama.server.net.ServerMessageWrapper;
+import org.schlunzis.kurtama.server.service.AbstractService;
 import org.schlunzis.kurtama.server.user.ServerUser;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.event.EventListener;
@@ -20,28 +19,30 @@ import java.util.Optional;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
-public class LobbyService {
+public class LobbyService extends AbstractService {
 
     private final LobbyStore lobbyStore;
-    private final ApplicationEventPublisher eventBus;
-    private final UserSessionMap userSessionMap;
+
+    public LobbyService(ApplicationEventPublisher eventBus, AuthenticationService authenticationService, LobbyStore lobbyStore) {
+        super(eventBus, authenticationService);
+        this.lobbyStore = lobbyStore;
+    }
 
     @EventListener
     public void onCreateLobbyRequest(ClientMessageWrapper<CreateLobbyRequest> cmw) {
         CreateLobbyRequest request = cmw.clientMessage();
 
-        Optional<ServerUser> user = userSessionMap.get(cmw.session());
+        Optional<ServerUser> user = authenticationService.getUserForSession(cmw.session());
         if (user.isPresent()) {
             ServerLobby lobby = lobbyStore.create(request.name());
             log.info("Created lobby with name: {} and id: {}", lobby.getName(), lobby.getId());
             lobby.joinUser(user.get());
             log.info("User {} joined lobby with id: {}", user.get().getId(), lobby.getId());
-            eventBus.publishEvent(new ServerMessageWrapper(new LobbyCreatedSuccessfullyResponse(lobby.toDTO()), cmw.session()));
+            sendTo(new LobbyCreatedSuccessfullyResponse(lobby.toDTO()), user.get());
             updateLobbyListInfo();
         } else {
             log.info("Could not create lobby. No user found for session.");
-            eventBus.publishEvent(new ServerMessageWrapper(new LobbyCreationFailedResponse(), cmw.session()));
+            sendTo(new LobbyCreationFailedResponse(), cmw.session());
         }
     }
 
@@ -49,17 +50,17 @@ public class LobbyService {
     public void onJoinLobbyRequest(ClientMessageWrapper<JoinLobbyRequest> cmw) {
         JoinLobbyRequest request = cmw.clientMessage();
 
-        Optional<ServerUser> user = userSessionMap.get(cmw.session());
+        Optional<ServerUser> user = authenticationService.getUserForSession(cmw.session());
         if (user.isPresent()) {
             ServerLobby lobby = lobbyStore.get(request.lobbyID());
             lobby.joinUser(user.get());
             log.info("User {} joined lobby with id: {}", user.get().getId(), lobby.getId());
-            eventBus.publishEvent(new ServerMessageWrapper(new JoinLobbySuccessfullyResponse(lobby.toDTO()), cmw.session()));
+            sendTo(new JoinLobbySuccessfullyResponse(lobby.toDTO()), user.get());
             // TODO update clients of users in lobby #8
             updateLobbyListInfo();
         } else {
             log.info("Could not join lobby. No user found for session.");
-            eventBus.publishEvent(new ServerMessageWrapper(new JoinLobbyFailedResponse(), cmw.session()));
+            sendTo(new JoinLobbyFailedResponse(), cmw.session());
         }
     }
 
@@ -67,12 +68,12 @@ public class LobbyService {
     public void onLeaveLobbyRequest(ClientMessageWrapper<LeaveLobbyRequest> cmw) {
         LeaveLobbyRequest request = cmw.clientMessage();
 
-        Optional<ServerUser> user = userSessionMap.get(cmw.session());
+        Optional<ServerUser> user = authenticationService.getUserForSession(cmw.session());
         if (user.isPresent()) {
             ServerLobby lobby = lobbyStore.get(request.lobbyID());
             lobby.leaveUser(user.get());
             log.info("User {} left lobby with id: {}", user.get().getId(), lobby.getId());
-            eventBus.publishEvent(new ServerMessageWrapper(new LeaveLobbySuccessfullyResponse(), cmw.session()));
+            sendTo(new LeaveLobbySuccessfullyResponse(), user.get());
             // TODO update clients of users in lobby #8
             if (lobby.getUsers().isEmpty()) {
                 lobbyStore.remove(lobby.getId());
@@ -81,13 +82,13 @@ public class LobbyService {
             updateLobbyListInfo();
         } else {
             log.info("Could not leave lobby. No user found for session.");
-            eventBus.publishEvent(new ServerMessageWrapper(new LobbyCreationFailedResponse(), cmw.session()));
+            sendTo(new LobbyCreationFailedResponse(), cmw.session());
         }
     }
 
     private void updateLobbyListInfo() {
         Collection<LobbyInfo> lobbyInfos = lobbyStore.getAll().stream().map(ServerLobby::getInfo).toList();
-        eventBus.publishEvent(new ServerMessageWrapper(new LobbyListInfoMessage(lobbyInfos), userSessionMap.getAllSessions()));
+        sendToAll(new LobbyListInfoMessage(lobbyInfos));
     }
 
 }

--- a/server/src/main/java/org/schlunzis/kurtama/server/service/AbstractService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/service/AbstractService.java
@@ -1,0 +1,72 @@
+package org.schlunzis.kurtama.server.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.schlunzis.kurtama.common.messages.IServerMessage;
+import org.schlunzis.kurtama.server.auth.IAuthenticationService;
+import org.schlunzis.kurtama.server.net.ISession;
+import org.schlunzis.kurtama.server.net.ServerMessageWrapper;
+import org.schlunzis.kurtama.server.user.ServerUser;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.util.Collection;
+
+/**
+ * A base class for all services, except the {@link org.schlunzis.kurtama.server.auth.AuthenticationService}.
+ * <p>
+ * This class provides basic functionality, for the services to send messages to users not sessions.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public abstract class AbstractService {
+
+    protected final ApplicationEventPublisher eventBus;
+    protected final IAuthenticationService authenticationService;
+
+    /**
+     * This method sends the given message to all logged-in clients.
+     *
+     * @param message the message to send
+     */
+    protected void sendToAll(IServerMessage message) {
+        eventBus.publishEvent(new ServerMessageWrapper(message, authenticationService.getAllLoggedInSessions()));
+    }
+
+    /**
+     * This method sends the given message to the given recipients.
+     *
+     * @param message    the message to send
+     * @param recipients the users, which should receive the message
+     */
+    protected void sendToMany(IServerMessage message, Collection<ServerUser> recipients) {
+        Collection<ISession> sessions = authenticationService.getSessionsForUsers(recipients);
+        if (sessions.size() != recipients.size()) {
+            log.warn("Tried to retrieve session for not logged-in users");
+        }
+        eventBus.publishEvent(new ServerMessageWrapper(message, sessions));
+    }
+
+    /**
+     * This method sends the given message to the given recipient.
+     *
+     * @param message   the message to send
+     * @param recipient the user, which should receive the message
+     */
+    protected void sendTo(IServerMessage message, ServerUser recipient) {
+        authenticationService.getSessionForUser(recipient).ifPresentOrElse(
+                r -> eventBus.publishEvent(new ServerMessageWrapper(message, r)),
+                () -> log.warn("Could not get session for user")
+        );
+    }
+
+    /**
+     * This method sends the given message to the given recipient.
+     *
+     * @param message   the message to send
+     * @param recipient the session, which should receive the message
+     */
+    protected void sendTo(IServerMessage message, ISession recipient) {
+        eventBus.publishEvent(new ServerMessageWrapper(message, recipient));
+    }
+
+}


### PR DESCRIPTION
Creating AbstractService and making UserSessionMap package private and accessible via the IAuthenticationService

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description
The UserSessionMap is now only accessible in the AuthenticationService and an AbstractService has been created to send messages easier. When #54 is implemented, the Services should not have to deal with sessions and authentication anymore.

## Related Tickets & Documents

- Related Issue(s) #54 
- Closes #77 


