### PR TITLE
Disabling joinLobby button when no lobby is selected

### DIFF
--- a/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
@@ -2,6 +2,7 @@ package org.schlunzis.kurtama.client.fx.controller;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
+import javafx.scene.control.Button;
 import javafx.scene.control.Dialog;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
@@ -34,6 +35,9 @@ public class MainMenuController {
     private ListView<LobbyInfo> lobbiesListView;
 
     @FXML
+    private Button joinLobbyButton;
+
+    @FXML
     private void initialize() {
         lobbiesListView.setItems(sessionService.getLobbyList());
         lobbiesListView.setCellFactory(lobbyInfoListView -> new ListCell<>() {
@@ -47,6 +51,16 @@ public class MainMenuController {
                 }
             }
         });
+        lobbiesListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                log.debug("Selected lobby: {}", newValue);
+                joinLobbyButton.setDisable(false);
+            } else {
+                log.debug("No lobby selected");
+                joinLobbyButton.setDisable(true);
+            }
+        });
+        joinLobbyButton.setDisable(true);
     }
 
     @FXML
@@ -61,8 +75,11 @@ public class MainMenuController {
     }
 
     @FXML
-    private void joinLobby(ActionEvent actionEvent) {
-        eventBus.publishEvent(new JoinLobbyRequest(lobbiesListView.getSelectionModel().getSelectedItem().lobbyID()));
+    private void joinLobby() {
+        LobbyInfo li = lobbiesListView.getSelectionModel().getSelectedItem();
+        if (li == null)
+            return;
+        eventBus.publishEvent(new JoinLobbyRequest(li.lobbyID()));
     }
 
     @FXML

--- a/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/fx/controller/MainMenuController.java
@@ -2,10 +2,7 @@ package org.schlunzis.kurtama.client.fx.controller;
 
 import javafx.event.ActionEvent;
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
-import javafx.scene.control.Dialog;
-import javafx.scene.control.ListCell;
-import javafx.scene.control.ListView;
+import javafx.scene.control.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.rgielen.fxweaver.core.FxmlView;
@@ -40,6 +37,7 @@ public class MainMenuController {
     @FXML
     private void initialize() {
         lobbiesListView.setItems(sessionService.getLobbyList());
+        lobbiesListView.getSelectionModel().setSelectionMode(SelectionMode.SINGLE);
         lobbiesListView.setCellFactory(lobbyInfoListView -> new ListCell<>() {
             @Override
             protected void updateItem(LobbyInfo lobbyInfo, boolean empty) {
@@ -51,14 +49,12 @@ public class MainMenuController {
                 }
             }
         });
-        lobbiesListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
-            if (newValue != null) {
-                log.debug("Selected lobby: {}", newValue);
-                joinLobbyButton.setDisable(false);
-            } else {
-                log.debug("No lobby selected");
-                joinLobbyButton.setDisable(true);
-            }
+        lobbiesListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) ->
+                joinLobbyButton.setDisable(newValue == null)
+        );
+        lobbiesListView.setOnMouseClicked(event -> {
+            if (event.getClickCount() == 2)
+                joinLobby();
         });
         joinLobbyButton.setDisable(true);
     }

--- a/client/src/main/resources/org/schlunzis/kurtama/client/fx/controller/main.fxml
+++ b/client/src/main/resources/org/schlunzis/kurtama/client/fx/controller/main.fxml
@@ -28,7 +28,7 @@
     <VBox GridPane.columnIndex="1" GridPane.rowIndex="0">
         <ListView fx:id="lobbiesListView"/>
         <HBox>
-            <Button mnemonicParsing="false" onAction="#joinLobby" text="Join Lobby"/>
+            <Button fx:id="joinLobbyButton" mnemonicParsing="false" onAction="#joinLobby" text="Join Lobby"/>
             <Button mnemonicParsing="false" onAction="#createLobby" text="CreateLobby"/>
         </HBox>
     </VBox>


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature
- Bug Fix


## Description
the joinLobby button is now disabled, when no lobby is selected. Also if the user somehow manages to trigger the join lobby button without a selection, nothing will happen, there will be no exception.

## Related Tickets & Documents

- Closes #89 


