### PR TITLE
Prepend packet length before sending

### DIFF
--- a/client/src/main/java/org/schlunzis/kurtama/client/net/impl/NettyClient.java
+++ b/client/src/main/java/org/schlunzis/kurtama/client/net/impl/NettyClient.java
@@ -7,6 +7,8 @@ import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +43,8 @@ public final class NettyClient implements INetworkClient {
                     @Override
                     public void initChannel(SocketChannel ch) {
                         ChannelPipeline p = ch.pipeline();
+                        p.addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+                        p.addLast(new LengthFieldPrepender(4));
                         p.addLast(new StringDecoder());
                         p.addLast(new StringEncoder());
                         // This is our custom client handler which will have logic for chat.

--- a/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/lobby/LobbyService.java
@@ -95,7 +95,7 @@ public class LobbyService {
             users.remove(cmc.getUser());
             cmc.sendToMany(message, users);
         } catch (LobbyNotFoundException e) {
-            log.error("Failed to inform users in lobby. Lobby not found. ", e);
+            log.debug("Could not inform other lobby members. Probably the last member in lobby left and the lobby was removed.");
         }
     }
 

--- a/server/src/main/java/org/schlunzis/kurtama/server/net/netty/NettyServer.java
+++ b/server/src/main/java/org/schlunzis/kurtama/server/net/netty/NettyServer.java
@@ -8,6 +8,8 @@ import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.codec.string.StringDecoder;
 import io.netty.handler.codec.string.StringEncoder;
 import lombok.extern.slf4j.Slf4j;
@@ -55,6 +57,8 @@ public class NettyServer implements INetworkServer {
                         @Override
                         public void initChannel(SocketChannel ch) {
                             ChannelPipeline p = ch.pipeline();
+                            p.addLast(new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, 4, 0, 4));
+                            p.addLast(new LengthFieldPrepender(4));
                             p.addLast(new StringDecoder());
                             p.addLast(new StringEncoder());
                             p.addLast(serverHandler);


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Bug Fix

## Description
In order to correctly tell apart messages send with netty, it can be needed to prepend the length of the sent message. This is especially important when messages are sent within a very short amount of time. Using `LengthFieldBasedFrameDecoder` and `lengthFieldLength` the length is prepended and the messages can be correctly decoded.
In case you are wondering where the hardcoded `4`s are coming from. I used Copilot to be sure how to integrate the concepts into the codebase and it generated a solution with these default values. Asking it for the reasons behind the choinces it answered the following:
>The `lengthFieldLength` parameter in both `LengthFieldBasedFrameDecoder` and `LengthFieldPrepender` is set to 4 because it represents the length of the length field that holds the length of the frame.  
>In this case, 4 bytes (32 bits) is chosen because it's a common choice for network protocols. It allows for a maximum frame length of 2^32 - 1, which is over 4 billion. This is more than enough for most applications, and it fits into a standard `int` data type in Java.  
>Remember, the choice of `lengthFieldLength` depends on the maximum message size your application needs to handle. If your messages are always small, you could choose a smaller length field, but 4 bytes is a good default for general use.

## Related Tickets & Documents

- Closes #134 


