### PR TITLE
push to ppa

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,8 @@ jobs:
       version: ${{ inputs.tag }}
     secrets: inherit
   
-  download-artifacts:
-    name: Download Artifacts
+  release:
+    name: Release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -52,11 +52,6 @@ jobs:
       - name: List artifacts
         run: ls -al
 
-  release:
-    needs: download-artifacts
-    runs-on: ubuntu-latest
-    name: Release Artifacts
-    steps:
       - name: Create release body
         run: |
           if [ "${{ inputs.prerelease }}" = "true" ]; then
@@ -81,19 +76,15 @@ jobs:
           artifacts: "*.jar,*.deb,*.exe"
           bodyFile: "release-body.md"
     
-  upload-ppa:
-    needs: download-artifacts
-    if: ${{ inputs.prerelease }} == 'false'
-    name: Release to PPA
-    runs-on: ubuntu-latest
-    steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.prerelease }} == 'false'
         name: Access PPA
         with:
           repository: schlunzis/ppa
           path: ppa
           token: ${{ secrets.PAT }}
       - name: Upload to PPA
+        if: ${{ inputs.prerelease }} == 'false'
         run: |
           cp *.deb ppa/ubuntu/
           cd ppa

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,9 @@ jobs:
     with:
       version: ${{ inputs.tag }}
     secrets: inherit
-
-  release:
-    name: Download and Release Artifacts
+  
+  download-artifacts:
+    name: Download Artifacts
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4
@@ -52,6 +52,11 @@ jobs:
       - name: List artifacts
         run: ls -al
 
+  release:
+    needs: download-artifacts
+    runs-on: ubuntu-latest
+    name: Release Artifacts
+    steps:
       - name: Create release body
         run: |
           if [ "${{ inputs.prerelease }}" = "true" ]; then
@@ -77,6 +82,7 @@ jobs:
           bodyFile: "release-body.md"
     
   upload-ppa:
+    needs: download-artifacts
     if: ${{ inputs.prerelease }} == 'false'
     name: Release to PPA
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,3 +75,24 @@ jobs:
           name: "Alpha Release: ${{ inputs.tag }}"
           artifacts: "*.jar,*.deb,*.exe"
           bodyFile: "release-body.md"
+    
+  upload-ppa:
+    if: ${{ inputs.prerelease }} == 'false'
+    name: Release to PPA
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        name: Access PPA
+        with:
+          repository: schlunzis/ppa
+          path: ppa
+          token: ${{ secrets.PAT }}
+      - name: Upload to PPA
+        run: |
+          cp *.deb ppa/ubuntu/
+          cd ppa
+          git config user.name "Package deployer (Bot)"
+          git config user.email "kurtama@schlunzis.org"
+          git add .
+          git commit -m "Kurtama Client $GITHUB_REF_NAME"
+          git push

--- a/.github/workflows/tagged-build.yml
+++ b/.github/workflows/tagged-build.yml
@@ -26,6 +26,7 @@ jobs:
     secrets: inherit
 
   release:
+    needs: build
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/tagged-build.yml
+++ b/.github/workflows/tagged-build.yml
@@ -19,13 +19,14 @@ jobs:
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
   build:
+    needs: create-version-string
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.create-version-string.outputs.version }}
     secrets: inherit
 
   release:
-    needs: build
+    needs: [build, create-version-string]
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ github.ref_name }}

--- a/.github/workflows/tagged-build.yml
+++ b/.github/workflows/tagged-build.yml
@@ -26,10 +26,8 @@ jobs:
     secrets: inherit
 
   release:
-    needs: [build, create-version-string]
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ github.ref_name }}
-      version: ${{ needs.create-version-string.outputs.version }}
       prerelease: false
     secrets: inherit

--- a/build-client.sh
+++ b/build-client.sh
@@ -30,8 +30,8 @@ if  [ "$os" = linux ]; then
   --app-version "${version}" \
   --dest ${destination} \
   --linux-package-name "kurtama-client" \
-  --linux-menu-group Game \
-  --linux-app-category Game \
+  --linux-menu-group Games \
+  --linux-app-category Games \
   --linux-shortcut
 
 


### PR DESCRIPTION
## What type of PR is this? (keep all applicable)

- Feature

## Description
All non-prerelease versions will now be pushed to the organizations ppa. Do notice: the PAT will expire with the end of the year on 31.12.2024 and needs to be renewed around that time.

## Related Tickets & Documents

- Closes #166 


